### PR TITLE
fix: fix modules links

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -20,6 +20,6 @@ ul { margin-top: 16px; margin-bottom: 16px; }
 <code>import "cosmossdk.io/api"</code>
 Home: <a href="https://pkg.go.dev/cosmossdk.io/api">https://pkg.go.dev/cosmossdk.io/api</a><br/>
 Source: <a href="https://github.com/cosmos/cosmos-sdk">https://github.com/cosmos/cosmos-sdk</a><br/>
-Sub-packages:<ul><li><a href="//math">cosmossdk.io//math</a></li><li><a href="//api">cosmossdk.io//api</a></li><li><a href="//depinject">cosmossdk.io//depinject</a></li><li><a href="//errors">cosmossdk.io//errors</a></li><li><a href="//core">cosmossdk.io//core</a></li><li><a href="//simapp">cosmossdk.io//simapp</a></li></ul></div>
+Sub-packages:<ul><li><a href="/math">cosmossdk.io/math</a></li><li><a href="/api">cosmossdk.io/api</a></li><li><a href="/depinject">cosmossdk.io/depinject</a></li><li><a href="/errors">cosmossdk.io/errors</a></li><li><a href="/core">cosmossdk.io/core</a></li><li><a href="/simapp">cosmossdk.io/simapp</a></li></ul></div>
 </body>
 </html>

--- a/core/index.html
+++ b/core/index.html
@@ -20,6 +20,6 @@ ul { margin-top: 16px; margin-bottom: 16px; }
 <code>import "cosmossdk.io/core"</code>
 Home: <a href="https://pkg.go.dev/cosmossdk.io/core">https://pkg.go.dev/cosmossdk.io/core</a><br/>
 Source: <a href="https://github.com/cosmos/cosmos-sdk">https://github.com/cosmos/cosmos-sdk</a><br/>
-Sub-packages:<ul><li><a href="//math">cosmossdk.io//math</a></li><li><a href="//api">cosmossdk.io//api</a></li><li><a href="//depinject">cosmossdk.io//depinject</a></li><li><a href="//errors">cosmossdk.io//errors</a></li><li><a href="//core">cosmossdk.io//core</a></li><li><a href="//simapp">cosmossdk.io//simapp</a></li></ul></div>
+Sub-packages:<ul><li><a href="/math">cosmossdk.io/math</a></li><li><a href="/api">cosmossdk.io/api</a></li><li><a href="/depinject">cosmossdk.io/depinject</a></li><li><a href="/errors">cosmossdk.io/errors</a></li><li><a href="/core">cosmossdk.io/core</a></li><li><a href="/simapp">cosmossdk.io/simapp</a></li></ul></div>
 </body>
 </html>

--- a/depinject/index.html
+++ b/depinject/index.html
@@ -20,6 +20,6 @@ ul { margin-top: 16px; margin-bottom: 16px; }
 <code>import "cosmossdk.io/depinject"</code>
 Home: <a href="https://pkg.go.dev/cosmossdk.io/depinject">https://pkg.go.dev/cosmossdk.io/depinject</a><br/>
 Source: <a href="https://github.com/cosmos/cosmos-sdk">https://github.com/cosmos/cosmos-sdk</a><br/>
-Sub-packages:<ul><li><a href="//math">cosmossdk.io//math</a></li><li><a href="//api">cosmossdk.io//api</a></li><li><a href="//depinject">cosmossdk.io//depinject</a></li><li><a href="//errors">cosmossdk.io//errors</a></li><li><a href="//core">cosmossdk.io//core</a></li><li><a href="//simapp">cosmossdk.io//simapp</a></li></ul></div>
+Sub-packages:<ul><li><a href="/math">cosmossdk.io/math</a></li><li><a href="/api">cosmossdk.io/api</a></li><li><a href="/depinject">cosmossdk.io/depinject</a></li><li><a href="/errors">cosmossdk.io/errors</a></li><li><a href="/core">cosmossdk.io/core</a></li><li><a href="/simapp">cosmossdk.io/simapp</a></li></ul></div>
 </body>
 </html>

--- a/errors/index.html
+++ b/errors/index.html
@@ -20,6 +20,6 @@ ul { margin-top: 16px; margin-bottom: 16px; }
 <code>import "cosmossdk.io/errors"</code>
 Home: <a href="https://pkg.go.dev/cosmossdk.io/errors">https://pkg.go.dev/cosmossdk.io/errors</a><br/>
 Source: <a href="https://github.com/cosmos/cosmos-sdk">https://github.com/cosmos/cosmos-sdk</a><br/>
-Sub-packages:<ul><li><a href="//math">cosmossdk.io//math</a></li><li><a href="//api">cosmossdk.io//api</a></li><li><a href="//depinject">cosmossdk.io//depinject</a></li><li><a href="//errors">cosmossdk.io//errors</a></li><li><a href="//core">cosmossdk.io//core</a></li><li><a href="//simapp">cosmossdk.io//simapp</a></li></ul></div>
+Sub-packages:<ul><li><a href="/math">cosmossdk.io/math</a></li><li><a href="/api">cosmossdk.io/api</a></li><li><a href="/depinject">cosmossdk.io/depinject</a></li><li><a href="/errors">cosmossdk.io/errors</a></li><li><a href="/core">cosmossdk.io/core</a></li><li><a href="/simapp">cosmossdk.io/simapp</a></li></ul></div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,6 @@ ul { margin-top: 16px; margin-bottom: 16px; }
 <code>import "cosmossdk.io/"</code>
 Home: <a href="https://pkg.go.dev/cosmossdk.io/">https://pkg.go.dev/cosmossdk.io/</a><br/>
 Source: <a href="https://github.com/cosmos/cosmos-sdk">https://github.com/cosmos/cosmos-sdk</a><br/>
-Sub-packages:<ul><li><a href="//math">cosmossdk.io//math</a></li><li><a href="//api">cosmossdk.io//api</a></li><li><a href="//depinject">cosmossdk.io//depinject</a></li><li><a href="//errors">cosmossdk.io//errors</a></li><li><a href="//core">cosmossdk.io//core</a></li><li><a href="//simapp">cosmossdk.io//simapp</a></li></ul></div>
+Sub-packages:<ul><li><a href="/math">cosmossdk.io/math</a></li><li><a href="/api">cosmossdk.io/api</a></li><li><a href="/depinject">cosmossdk.io/depinject</a></li><li><a href="/errors">cosmossdk.io/errors</a></li><li><a href="/core">cosmossdk.io/core</a></li><li><a href="/simapp">cosmossdk.io/simapp</a></li></ul></div>
 </body>
 </html>

--- a/math/index.html
+++ b/math/index.html
@@ -20,6 +20,6 @@ ul { margin-top: 16px; margin-bottom: 16px; }
 <code>import "cosmossdk.io/math"</code>
 Home: <a href="https://pkg.go.dev/cosmossdk.io/math">https://pkg.go.dev/cosmossdk.io/math</a><br/>
 Source: <a href="https://github.com/cosmos/cosmos-sdk">https://github.com/cosmos/cosmos-sdk</a><br/>
-Sub-packages:<ul><li><a href="//math">cosmossdk.io//math</a></li><li><a href="//api">cosmossdk.io//api</a></li><li><a href="//depinject">cosmossdk.io//depinject</a></li><li><a href="//errors">cosmossdk.io//errors</a></li><li><a href="//core">cosmossdk.io//core</a></li><li><a href="//simapp">cosmossdk.io//simapp</a></li></ul></div>
+Sub-packages:<ul><li><a href="/math">cosmossdk.io/math</a></li><li><a href="/api">cosmossdk.io/api</a></li><li><a href="/depinject">cosmossdk.io/depinject</a></li><li><a href="/errors">cosmossdk.io/errors</a></li><li><a href="/core">cosmossdk.io/core</a></li><li><a href="/simapp">cosmossdk.io/simapp</a></li></ul></div>
 </body>
 </html>

--- a/simapp/index.html
+++ b/simapp/index.html
@@ -20,6 +20,6 @@ ul { margin-top: 16px; margin-bottom: 16px; }
 <code>import "cosmossdk.io/simapp"</code>
 Home: <a href="https://pkg.go.dev/cosmossdk.io/simapp">https://pkg.go.dev/cosmossdk.io/simapp</a><br/>
 Source: <a href="https://github.com/cosmos/cosmos-sdk">https://github.com/cosmos/cosmos-sdk</a><br/>
-Sub-packages:<ul><li><a href="//math">cosmossdk.io//math</a></li><li><a href="//api">cosmossdk.io//api</a></li><li><a href="//depinject">cosmossdk.io//depinject</a></li><li><a href="//errors">cosmossdk.io//errors</a></li><li><a href="//core">cosmossdk.io//core</a></li><li><a href="//simapp">cosmossdk.io//simapp</a></li></ul></div>
+Sub-packages:<ul><li><a href="/math">cosmossdk.io/math</a></li><li><a href="/api">cosmossdk.io/api</a></li><li><a href="/depinject">cosmossdk.io/depinject</a></li><li><a href="/errors">cosmossdk.io/errors</a></li><li><a href="/core">cosmossdk.io/core</a></li><li><a href="/simapp">cosmossdk.io/simapp</a></li></ul></div>
 </body>
 </html>


### PR DESCRIPTION
Fix the submodules links using the latest vangen fix: https://github.com/leighmcculloch/vangen/pull/18