### PR TITLE
chore: remove non sdk modules released from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,25 +1,77 @@
 <!DOCTYPE html>
 <html>
-<head>
-<meta charset="utf-8">
-<title>cosmossdk.io/</title>
-<meta name="go-import" content="cosmossdk.io/ git https://github.com/cosmos/cosmos-sdk">
-<meta name="go-source" content="cosmossdk.io/ https://github.com/cosmos/cosmos-sdk https://github.com/cosmos/cosmos-sdk/tree/main{/dir} https://github.com/cosmos/cosmos-sdk/blob/main{/dir}/{file}#L{line}">
-<style>
-* { font-family: sans-serif; }
-body { margin-top: 0; }
-.content { display: inline-block; }
-code { display: block; font-family: monospace; font-size: 1em; background-color: #d5d5d5; padding: 1em; margin-bottom: 16px; }
-ul { margin-top: 16px; margin-bottom: 16px; }
-</style>
-</head>
-<body>
-<div class="content">
-<h2>cosmossdk.io/</h2>
-<code>go get cosmossdk.io/</code>
-<code>import "cosmossdk.io/"</code>
-Home: <a href="https://pkg.go.dev/cosmossdk.io/">https://pkg.go.dev/cosmossdk.io/</a><br/>
-Source: <a href="https://github.com/cosmos/cosmos-sdk">https://github.com/cosmos/cosmos-sdk</a><br/>
-Sub-packages:<ul><li><a href="/math">cosmossdk.io/math</a></li><li><a href="/api">cosmossdk.io/api</a></li><li><a href="/depinject">cosmossdk.io/depinject</a></li><li><a href="/errors">cosmossdk.io/errors</a></li><li><a href="/core">cosmossdk.io/core</a></li><li><a href="/collections">cosmossdk.io/collections</a></li><li><a href="/simapp">cosmossdk.io/simapp</a></li><li><a href="/store">cosmossdk.io/store</a></li><li><a href="/client/v2">cosmossdk.io/client/v2</a></li><li><a href="/log">cosmossdk.io/log</a></li><li><a href="/orm">cosmossdk.io/orm</a></li><li><a href="/tools/cosmovisor">cosmossdk.io/tools/cosmovisor</a></li><li><a href="/tools/rosetta">cosmossdk.io/tools/rosetta</a></li><li><a href="/tools/confix">cosmossdk.io/tools/confix</a></li><li><a href="/tools/hubl">cosmossdk.io/tools/hubl</a></li><li><a href="/x/accounts">cosmossdk.io/x/accounts</a></li><li><a href="/x/auth">cosmossdk.io/x/auth</a></li><li><a href="/x/authz">cosmossdk.io/x/authz</a></li><li><a href="/x/bank">cosmossdk.io/x/bank</a></li><li><a href="/x/circuit">cosmossdk.io/x/circuit</a></li><li><a href="/x/distribution">cosmossdk.io/x/distribution</a></li><li><a href="/x/feegrant">cosmossdk.io/x/feegrant</a></li><li><a href="/x/evidence">cosmossdk.io/x/evidence</a></li><li><a href="/x/gov">cosmossdk.io/x/gov</a></li><li><a href="/x/group">cosmossdk.io/x/group</a></li><li><a href="/x/protocolpool">cosmossdk.io/x/protocolpool</a></li><li><a href="/x/params">cosmossdk.io/x/params</a></li><li><a href="/x/mint">cosmossdk.io/x/mint</a></li><li><a href="/x/nft">cosmossdk.io/x/nft</a></li><li><a href="/x/slashing">cosmossdk.io/x/slashing</a></li><li><a href="/x/staking">cosmossdk.io/x/staking</a></li><li><a href="/x/tx">cosmossdk.io/x/tx</a></li><li><a href="/x/upgrade">cosmossdk.io/x/upgrade</a></li></ul></div>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>cosmossdk.io/</title>
+    <meta
+      name="go-import"
+      content="cosmossdk.io/ git https://github.com/cosmos/cosmos-sdk"
+    />
+    <meta
+      name="go-source"
+      content="cosmossdk.io/ https://github.com/cosmos/cosmos-sdk https://github.com/cosmos/cosmos-sdk/tree/main{/dir} https://github.com/cosmos/cosmos-sdk/blob/main{/dir}/{file}#L{line}"
+    />
+    <style>
+      * {
+        font-family: sans-serif;
+      }
+      body {
+        margin-top: 0;
+      }
+      .content {
+        display: inline-block;
+      }
+      code {
+        display: block;
+        font-family: monospace;
+        font-size: 1em;
+        background-color: #d5d5d5;
+        padding: 1em;
+        margin-bottom: 16px;
+      }
+      ul {
+        margin-top: 16px;
+        margin-bottom: 16px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="content">
+      <h2>cosmossdk.io/</h2>
+      <code>go get cosmossdk.io/</code>
+      <code>import "cosmossdk.io/"</code>
+      Home:
+      <a href="https://pkg.go.dev/cosmossdk.io/"
+        >https://pkg.go.dev/cosmossdk.io/</a
+      ><br />
+      Source:
+      <a href="https://github.com/cosmos/cosmos-sdk"
+        >https://github.com/cosmos/cosmos-sdk</a
+      ><br />
+      Sub-packages:
+      <ul>
+        <li><a href="/math">cosmossdk.io/math</a></li>
+        <li><a href="/api">cosmossdk.io/api</a></li>
+        <li><a href="/depinject">cosmossdk.io/depinject</a></li>
+        <li><a href="/errors">cosmossdk.io/errors</a></li>
+        <li><a href="/core">cosmossdk.io/core</a></li>
+        <li><a href="/collections">cosmossdk.io/collections</a></li>
+        <li><a href="/simapp">cosmossdk.io/simapp</a></li>
+        <li><a href="/store">cosmossdk.io/store</a></li>
+        <li><a href="/client/v2">cosmossdk.io/client/v2</a></li>
+        <li><a href="/log">cosmossdk.io/log</a></li>
+        <li><a href="/orm">cosmossdk.io/orm</a></li>
+        <li><a href="/tools/cosmovisor">cosmossdk.io/tools/cosmovisor</a></li>
+        <li><a href="/tools/rosetta">cosmossdk.io/tools/rosetta</a></li>
+        <li><a href="/tools/confix">cosmossdk.io/tools/confix</a></li>
+        <li><a href="/tools/hubl">cosmossdk.io/tools/hubl</a></li>
+        <li><a href="/x/circuit">cosmossdk.io/x/circuit</a></li>
+        <li><a href="/x/feegrant">cosmossdk.io/x/feegrant</a></li>
+        <li><a href="/x/evidence">cosmossdk.io/x/evidence</a></li>
+        <li><a href="/x/nft">cosmossdk.io/x/nft</a></li>
+        <li><a href="/x/tx">cosmossdk.io/x/tx</a></li>
+        <li><a href="/x/upgrade">cosmossdk.io/x/upgrade</a></li>
+      </ul>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
Currently, it isn't clear which modules are available and which aren't.
This simply removes the ones that aren't available until 0.51 to no confuse users.
Note, if we extract other modules and re-generate the file, let's not forget to cherry-pick this commit.